### PR TITLE
Bump npm from 7.20.1 to 8.3.2

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,1 @@
-engine-strict=true
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM node:16.13.2-buster as node
-RUN npm install -g npm@7.20.1 --quiet
+RUN npm install -g npm@8.3.2 --quiet
 
 FROM python:3.10.2-buster as python
 FROM koalaman/shellcheck:v0.8.0 as shellcheck

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "engines": {
     "node": "16",
-    "npm": "7"
+    "npm": "8"
   },
   "scripts": {
     "prepare": "husky install"


### PR DESCRIPTION
- Remove `engine-strict`
- Bump `npm` engines from 7 to 8